### PR TITLE
Strict mode fix

### DIFF
--- a/src/core/createStyleFunction.ts
+++ b/src/core/createStyleFunction.ts
@@ -8,7 +8,7 @@ import {
 } from '../types';
 
 const defaultTransform: Transform = ({ path, object, strict, get }) => {
-  return get(object, path, strict === true ? undefined : path);
+  return get(object, path, strict === true && !!object ? undefined : path);
 };
 
 export const createStyleFunction: StyleFunction = ({

--- a/src/core/tests/system.test.ts
+++ b/src/core/tests/system.test.ts
@@ -155,6 +155,8 @@ test('gets values from theme', () => {
 test('if strict, only allows theme values', () => {
   const system = createSystem({ strict: true });
   const parser = system({
+    // verify that the strict mode allows properties that don't rely on theme values
+    textAlign: true,
     mx: {
       properties: ['marginLeft', 'marginRight'],
       scale: 'space',
@@ -179,6 +181,7 @@ test('if strict, only allows theme values', () => {
     mx: ['$0', '$1', '$2', '$3', '$4'],
     color: ['$primary', 'black'],
     bg: 'blue',
+    textAlign: 'center',
   });
   expect(style).toEqual({
     color: 'tomato',
@@ -196,6 +199,7 @@ test('if strict, only allows theme values', () => {
       marginLeft: 24,
       marginRight: 24,
     },
+    textAlign: 'center',
   });
 });
 


### PR DESCRIPTION
Prevent strict mode from being applied to properties that don't have an associated theme scale.

This fixes https://github.com/system-props/system-props/issues/53.